### PR TITLE
Focus chat keyboard shortcut for claude (just like chatgpt)

### DIFF
--- a/claude.user.js
+++ b/claude.user.js
@@ -1,23 +1,34 @@
 // ==UserScript==
 // @name         Claude.ai Shortcuts
 // @namespace    Smart User Scripts
-// @version      0.1
-// @description  Open Claude.ai new chat when pressing Ctrl+Shift+O
+// @version      0.3
+// @description  Open Claude.ai new chat with Ctrl+Shift+O, Focus Input with Shift+Escape
 // @match        https://claude.ai/*
 // @grant        none
-// @author      Smart Manoj
-// @updateURL   https://raw.githubusercontent.com/SmartManoj/smart-user-scripts/main/claude.user.js
+// @author       Smart Manoj
+// @updateURL    https://raw.githubusercontent.com/SmartManoj/smart-user-scripts/main/claude.user.js
 // ==/UserScript==
-
-
 
 (function() {
     'use strict';
 
+    // Open new chat with Ctrl+Shift+O
     document.addEventListener('keydown', function(e) {
         if (e.ctrlKey && e.shiftKey && e.key === 'O') {
             e.preventDefault();
             window.open('https://claude.ai/chat/new', '_self');
+        }
+    });
+
+    // Focus on the contenteditable div with Shift+Escape
+    document.addEventListener('keydown', function(e) {
+        if (e.shiftKey && e.key === 'Escape') {
+            e.preventDefault();
+            // Query the contenteditable div
+            const editableDiv = document.querySelector('div[contenteditable="true"]');
+            if (editableDiv) {
+                editableDiv.focus();
+            }
         }
     });
 })();


### PR DESCRIPTION
In chatgpt there is a keyboard shortcut(Shift + Escape) to focus chat,  having the same for claude will be nice, i updated your script. Thanks for creating this, super useful 🔥